### PR TITLE
Fix for XML Formatting Options

### DIFF
--- a/packages/bruno-app/src/utils/common/index.js
+++ b/packages/bruno-app/src/utils/common/index.js
@@ -51,12 +51,12 @@ export const safeStringifyJSON = (obj, indent = false) => {
   }
 };
 
-export const safeParseXML = (str) => {
+export const safeParseXML = (str, options) => {
   if (!str || !str.length || typeof str !== 'string') {
     return str;
   }
   try {
-    return xmlFormat(str);
+    return xmlFormat(str, options);
   } catch (e) {
     return str;
   }


### PR DESCRIPTION
SafeParseXML - Option for collapseContent: true in QueryResult/index is not being passed to XML-Formatter.